### PR TITLE
#16 Updated readme to show default import in browser use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ fs.readFile('./test.mid', 'base64', function (err,data) {
 Example in Browser...
 ```html
 <script type="module">
-  import {MidiParser} from 'midi-parser.js'
+  import MidiParser from 'midi-parser.js'
   // select the INPUT element that will handle
   // the file selection.
   let source = document.getElementById('filereader');


### PR DESCRIPTION
Pull request to fix open issue #16, documentation previously showed named import in browser use case when the import should be unnamed.