### PR TITLE
Bug fixes for unimplemented meta event

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -260,7 +260,6 @@
                                 // if no customInterpretr is provided, or returned
                                 // false (=apply default), perform default action
                                 if(this.customInterpreter === null || MIDI.track[t-1].event[e-1].data === false){
-                                    file.readInt(metaEventLength);
                                     MIDI.track[t-1].event[e-1].data = file.readInt(metaEventLength);
                                     if (this.debug) console.info('Unimplemented 0xFF meta event! data block readed as Integer');
                                 }


### PR DESCRIPTION
This is a fix for the bug mentioned in issue 19. Since the same data is read twice, it cannot follow the file structure afterwards. This is simply solved by removing the unnecessary read function. I've attached a MIDI file to test it out in the link **below**. Before the fix, the data of MIDI messages came out in a jumbled mess. After the fix, it comes out as intended.

https://drive.google.com/file/d/1feeOInSjyom5dAI_OQcyW1-8AJeTiIKf/view?usp=sharing